### PR TITLE
Disconnect salesforce flow

### DIFF
--- a/app/src/main/java/com/truesparrow/sales/repository/AuthenticationRepository.kt
+++ b/app/src/main/java/com/truesparrow/sales/repository/AuthenticationRepository.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.truesparrow.sales.api.ApiService
+import com.truesparrow.sales.common_components.CustomToast
 import com.truesparrow.sales.models.SalesForceConnectRequest
 import com.truesparrow.sales.models.RedirectUrl
 import com.truesparrow.sales.models.CurrentUserResponse
@@ -28,6 +29,11 @@ class AuthenticationRepository @Inject constructor(
     private val _getSalesForcceConnectUrl = MutableLiveData<NetworkResponse<RedirectUrl>>()
     val getSalesForcceConnectUrl: LiveData<NetworkResponse<RedirectUrl>>
         get() = _getSalesForcceConnectUrl
+
+    private val _salesForceDisconnect = MutableLiveData<NetworkResponse<Unit>>()
+    val salesForceDisconnect: LiveData<NetworkResponse<Unit>>
+        get() = _salesForceDisconnect
+
 
     suspend fun getConnectWithSalesForceUrl(
         redirectUri: String
@@ -112,12 +118,25 @@ class AuthenticationRepository @Inject constructor(
         }
     }
 
-    suspend fun disconnectSalesForce(): Boolean {
-        return try {
+    suspend fun disconnectSalesForce() {
+         try {
+
             val response = apiService.disconnectSalesForce();
+
+             if (response.isSuccessful) {
+                 NavigationService.navigateWithPopUpClearingAllStack(Screens.LoginScreen.route)
+                 cookieManager.clearCookie();
+
+             } else if (response.errorBody() != null) {
+                 val errorObj = JSONObject(response.errorBody()!!.charStream().readText())
+
+             } else {
+
+             }
+            cookieManager.clearCookie();
             response.isSuccessful
         } catch (e: Exception) {
-            false
+
         }
     }
 

--- a/app/src/main/java/com/truesparrow/sales/screens/LoginScreen.kt
+++ b/app/src/main/java/com/truesparrow/sales/screens/LoginScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -46,8 +48,10 @@ import com.truesparrow.sales.R
 import com.truesparrow.sales.common_components.CustomButton
 import com.truesparrow.sales.common_components.CustomText
 import com.truesparrow.sales.common_components.CustomTextWithImage
+import com.truesparrow.sales.common_components.CustomToast
 import com.truesparrow.sales.common_components.HorizontalBar
 import com.truesparrow.sales.common_components.TermsAndConditionComponent
+import com.truesparrow.sales.common_components.ToastType
 import com.truesparrow.sales.util.NetworkResponse
 import com.truesparrow.sales.viewmodals.AuthenticationViewModal
 
@@ -60,6 +64,25 @@ fun LogInScreen(intent: Intent?) {
 
 
     var isLogInProgress = remember { mutableStateOf(false) }
+
+    val discconnectSalesForceResponse by authenticationViewModal.salesForceDisconnect.observeAsState()
+    
+    discconnectSalesForceResponse?.let {
+        when (it) {
+            is NetworkResponse.Success -> {
+                CustomToast(message = "Your account has been disconnected and detailed deleted  ", type = ToastType.Success)
+                Log.i("SalesSparow", " LogInScreen: ${it.data}")
+            }
+
+            is NetworkResponse.Loading -> {
+           
+            }
+
+            is NetworkResponse.Error -> {
+               
+            }
+        }
+    };
 
     authenticationViewModal.getSalesForcceConnectUrl.observe(
         LocalLifecycleOwner.current

--- a/app/src/main/java/com/truesparrow/sales/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/truesparrow/sales/screens/SettingsScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.truesparrow.sales.BuildConfig
 import com.truesparrow.sales.R
+import com.truesparrow.sales.common_components.CustomAlertDialog
 import com.truesparrow.sales.common_components.UserAvatar
 import com.truesparrow.sales.services.NavigationService
 import com.truesparrow.sales.viewmodals.AuthenticationViewModal
@@ -57,10 +58,11 @@ import com.truesparrow.sales.viewmodals.AuthenticationViewModal
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun SettingsScreen() {
-    var switchCheckedState by remember { mutableStateOf(false) }
+    var switchCheckedState by remember { mutableStateOf(true) }
     val authenticationViewModal: AuthenticationViewModal = hiltViewModel();
     val currentUser =
         authenticationViewModal.currentUserLiveData?.observeAsState()?.value?.data?.current_user
+    val openDialogForSalesForceDisconnect = remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -69,6 +71,20 @@ fun SettingsScreen() {
     ) {
         SettingHeader()
         Spacer(modifier = Modifier.padding(top = 20.dp))
+
+        CustomAlertDialog(
+            title = "Disconnect Salesforce",
+            message = "This will delete your account and all details associated with it. This is an irreversible process, are you sure you want to do this?",
+            onConfirmButtonClick = {
+                authenticationViewModal.disconnectSalesForce()
+                openDialogForSalesForceDisconnect.value = false
+            },
+            onDismissRequest = {
+                openDialogForSalesForceDisconnect.value = false
+            },
+            showConfirmationDialog = openDialogForSalesForceDisconnect.value
+        )
+
         Row(
             horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
             verticalAlignment = Alignment.CenterVertically,
@@ -135,10 +151,13 @@ fun SettingsScreen() {
                             shape = RoundedCornerShape(size = 4.dp)
                         )
                         .padding(start = 4.dp, top = 2.dp, end = 8.dp, bottom = 2.dp)
+                        .clickable {
+                            openDialogForSalesForceDisconnect.value = true
+                        }
                 ) {
                     Switch(
                         checked = switchCheckedState,
-                        onCheckedChange = { switchCheckedState = it }
+                        onCheckedChange = { switchCheckedState = true }
                     )
                     Text(
                         text = "Disconnect Salesforce",

--- a/app/src/main/java/com/truesparrow/sales/viewmodals/AuthenticationViewModal.kt
+++ b/app/src/main/java/com/truesparrow/sales/viewmodals/AuthenticationViewModal.kt
@@ -29,6 +29,8 @@ class AuthenticationViewModal @Inject constructor(
     val getSalesForcceConnectUrl: LiveData<NetworkResponse<RedirectUrl>>
         get() = authenticationRepository.getSalesForcceConnectUrl
 
+    val salesForceDisconnect: LiveData<NetworkResponse<Unit>>
+        get() = authenticationRepository.salesForceDisconnect
 
     init {
         viewModelScope.launch {
@@ -77,7 +79,7 @@ class AuthenticationViewModal @Inject constructor(
     fun disconnectSalesForce() {
         viewModelScope.launch {
             authenticationRepository.disconnectSalesForce()
-            NavigationService.navigateTo(Screens.LoginScreen.route);
+            NavigationService.navigateWithPopUpClearingAllStack(Screens.LoginScreen.route)
         }
     }
 }


### PR DESCRIPTION
## Summary:
 - New Feature: Added functionality to disconnect from Salesforce. Users can now disconnect their Salesforce account from the settings screen.
New Feature: Implemented a custom alert dialog for confirming Salesforce disconnection. This provides an additional layer of confirmation before disconnecting.
New Feature: Introduced a custom toast component to display success and error messages related to Salesforce disconnection.
Refactor: Updated navigation method in AuthenticationViewModal for better user experience after disconnecting from Salesforce.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes:**

- New Feature: Added functionality to disconnect from Salesforce. Users can now disconnect their Salesforce account from the settings screen.
- New Feature: Implemented a custom alert dialog for confirming Salesforce disconnection. This provides an additional layer of confirmation before disconnecting.
- New Feature: Introduced a custom toast component to display success and error messages related to Salesforce disconnection.
- Refactor: Updated navigation method in `AuthenticationViewModal` for better user experience after disconnecting from Salesforce.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->