### PR TITLE
updated build version and terms and privacy links

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ android {
     productFlavors {
 
         create("production") {
-            versionCode = 2
+            versionCode = 4
             versionName = "1.0.0"
             resValue("string", "app_name", "SalesSparrow")
             buildConfigField(

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 
     <application
         android:name=".SalesSparrowApplication"

--- a/app/src/main/java/com/truesparrow/sales/common_components/TermsAndConditionComponent.kt
+++ b/app/src/main/java/com/truesparrow/sales/common_components/TermsAndConditionComponent.kt
@@ -41,7 +41,7 @@ fun TermsAndConditionComponent(
         }
         pushStringAnnotation(
             tag = "terms",
-            annotation = "https://www.truesparrow.com"
+            annotation = "https://drive.google.com/file/d/1kccg9XL2D0QEtCV09Bn8icStNX1PAF5E/view"
         )
         withStyle(
             style = SpanStyle(
@@ -68,7 +68,7 @@ fun TermsAndConditionComponent(
         }
         pushStringAnnotation(
             tag = "privacy",
-            annotation = "https://www.truesparrow.com"
+            annotation = "https://drive.google.com/file/d/1kccg9XL2D0QEtCV09Bn8icStNX1PAF5E/view"
         )
         withStyle(
             style = SpanStyle(
@@ -90,14 +90,14 @@ fun TermsAndConditionComponent(
         onClick = { offset ->
             annotedString.getStringAnnotations(tag = "terms", start = offset, end = offset)
                 .firstOrNull()?.let {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse( "https://truesparrow.com/terms"));
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse( "https://drive.google.com/file/d/1pOQOLw_yt1aF9QXHlJag2YgaFmwtMf3Y/view"));
                     context.startActivity(intent);
                     Log.d("terms URL", it.item)
                 }
 
             annotedString.getStringAnnotations(tag = "privacy", start = offset, end = offset)
                 .firstOrNull()?.let {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse( "https://truesparrow.com/privacy"));
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse( "https://drive.google.com/file/d/1kccg9XL2D0QEtCV09Bn8icStNX1PAF5E/view"));
                     context.startActivity(intent);
                     Log.d("policy URL", it.item)
                 }


### PR DESCRIPTION
## Summary:
 - updated build version and terms and privacy links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the `versionCode` for the production build from 2 to 4. This change will not impact end-users directly but is important for app versioning and updates.
- Refactor: Removed the `com.google.android.gms.permission.AD_ID` permission from the Android manifest file. This change enhances user privacy by reducing unnecessary permissions.
- New Feature: Updated the URLs in the `TermsAndConditionComponent` to point to new terms and privacy documents hosted on Google Drive. Users will now be directed to these updated documents when accessing terms and conditions or privacy information.
- Documentation: Updated the subproject commit in the docs. This change does not affect the end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->